### PR TITLE
Latin/Latin-ext settings for google fonts

### DIFF
--- a/src/default.hbs
+++ b/src/default.hbs
@@ -27,7 +27,7 @@
     <link href="/apple-touch-icon-precomposed.png" rel="apple-touch-icon">
 
     <link href="//fonts.googleapis.com/" rel="dns-prefetch">
-    <link href="//fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic|Open+Sans:700,400" rel="stylesheet">
+    <link href="//fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic|Open+Sans:700,400&subset=latin,latin-ext" rel="stylesheet">
 
     <!-- build:css({src,.tmp}) /assets/css/main.min.css -->
     <link href="/assets/_components/font-awesome/css/font-awesome.css">


### PR DESCRIPTION
I've added latin and latin-ext subset to google fonts. I'll be using ghostium in polish and without it specific polish chars (like ą ł ń etc.) were displayed incorectly.
