### PR TITLE
Introducing "dryrun" grunt task for development usage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -418,6 +418,18 @@ module.exports = function(grunt) {
   ]);
 
   /**
+   * Dry-run task
+   * Run `grunt dryrun` on the command line
+   * Build and move bundled files to root
+   */
+  grunt.registerTask('dryrun', 'Build and move bundled files to root', [
+    'build',
+    'clean:release',
+    'copy:release',
+    'clean:build'
+  ]);
+
+  /**
    * Release task
    * Run `grunt release` on the command line
    * Build, move builded files to root, bump and update changelog
@@ -428,10 +440,7 @@ module.exports = function(grunt) {
     function(versionType) {
       grunt.task.run('push:' + (versionType || '') + ':bump-only');
       grunt.task.run([
-        'build',
-        'clean:release',
-        'copy:release',
-        'clean:build',
+        'dryrun',
         'changelog'
       ]);
       grunt.task.run('push-commit');


### PR DESCRIPTION
`grunt release` bumps the project version, updates changelog, commits and pushes, all of which are not ideal for incremental development testing. This change abstracts the build steps from the `release` task into a new `dryrun` task which can be used to generate build output without any impact on the state of the project or repository.
