### PR TITLE
Syntax fontsize

### DIFF
--- a/src/assets/_scss/vendor/_prism.scss
+++ b/src/assets/_scss/vendor/_prism.scss
@@ -1,9 +1,13 @@
 code[class*="language-"],
 pre[class*="language-"] {
-  font-size: 14px;
+  font-size: 80%;
   max-width: 100%;
   word-wrap: break-word;
   word-break: break-all;
+}
+
+pre[class*="language-"] code[class*="language-"] {
+  font-size: inherit;
 }
 
 pre[class*="language-"] {


### PR DESCRIPTION
The font-size of pre/code elements should be relative, not fixed.

Example reason: a nested pre/code element in a heading.
