### PR TITLE
Remove grunt-concurrent

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -334,22 +334,6 @@ module.exports = function(grunt) {
     },
 
     /**
-     * Run SASS and image/svg minification tasks at same time
-     */
-    concurrent: {
-      options: {
-        logConcurrentOutput: true
-      },
-      build: {
-        tasks: [
-          'imagemin:build',
-          'svgmin:build',
-          'autoprefixer:build'
-        ]
-      },
-    },
-
-    /**
      * Bump version on package.json and bower.json
      */
     push: {
@@ -413,7 +397,9 @@ module.exports = function(grunt) {
     'rev',
     'copy:build',
     'usemin',
-    'concurrent:build',
+    'imagemin:build',
+    'svgmin:build',
+    'autoprefixer:build',
     'csso:build'
   ]);
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "grunt-rev": "~0.1.0",
     "grunt-svgmin": "~0.2.0",
     "grunt-usemin": "~2.0.0",
-    "grunt-concurrent": "~0.4.1",
     "grunt-push-release": "~0.1.1",
     "grunt-conventional-changelog": "~1.0.0",
     "grunt-csso": "~0.5.0"


### PR DESCRIPTION
grunt-concurrent poses issues for low memory VM's and cloud instances.

Trying to perform a build on a 512MB cloud server fails; spooling up imagemin, svgmin, and autoprefixer all concurrently pushes beyond the resource ceiling, killing the concurrent task and aborting the build all-together. This is in spite of Ghostium not having any assets for imagemin or svgmin to process by default. And, that said, it shouldn't be much of a build time/performance hit to run these tasks consecutively instead of concurrently...
