### PR TITLE
Fix undesired wrapping of pre-formatted text

### DIFF
--- a/src/assets/_scss/vendor/_prism.scss
+++ b/src/assets/_scss/vendor/_prism.scss
@@ -2,12 +2,14 @@ code[class*="language-"],
 pre[class*="language-"] {
   font-size: 80%;
   max-width: 100%;
-  word-wrap: break-word;
-  word-break: break-all;
+  word-wrap: break-word; // allow wrapping within content blocks
+  word-break: break-all; // allow wrapping within content blocks
 }
 
 pre[class*="language-"] code[class*="language-"] {
   font-size: inherit;
+  word-wrap: normal; // prohibit wrapping within code blocks; scroll x overflow
+  word-break: normal; // prohibit wrapping within code blocks; scroll x overflow
 }
 
 pre[class*="language-"] {


### PR DESCRIPTION
This change still allows word wrapping when a `pre` or `code` element is used within a content block (i.e., a paragraph with a code element) but falls back to natural horizontal overflow scrolling when a `code` element is nested within a `pre` element (which is what Prism does).
