### PR TITLE
Add post tag separator

### DIFF
--- a/partials/post/list.hbs
+++ b/partials/post/list.hbs
@@ -19,9 +19,7 @@
       </li>
       {{#if tags}}
         <li class="post-item-meta-item">
-          {{#foreach tags}}
-            <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
-          {{/foreach}}
+          <span>{{tags separator=", "}}</span>
         </li>
       {{/if}}
       <li class="post-item-meta-item">

--- a/post.hbs
+++ b/post.hbs
@@ -14,9 +14,7 @@
               </li>
               {{#if tags}}
                 <li class="post-meta-item">
-                  {{#foreach tags}}
-                    <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
-                  {{/foreach}}
+                  <span>{{tags separator=", "}}</span>
                 </li>
               {{/if}}
               <li class="post-meta-item">


### PR DESCRIPTION
I was looking into adding separators for multiple tags on my posts and was wondering what the thinking was behind out post tags are displayed

``` html
{{#foreach tags}}
  <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
{{/foreach}}
```

In particular the individual spans for each tag and the different class names. In any event I've started just using this on 

``` html
<span>{{tags separator=", "}}</span>
```

Perhaps it's just a visual preference. If you feel it doesn't add anything to ghostium feel free to reject this, I won't be hurt :)
