### PR TITLE
Fix word-wrap/word-break causing inline code blocks to wrap mid-word

### DIFF
--- a/src/assets/_scss/vendor/_prism.scss
+++ b/src/assets/_scss/vendor/_prism.scss
@@ -3,7 +3,8 @@ pre[class*="language-"] {
   font-size: 80%;
   max-width: 100%;
   word-wrap: break-word; // allow wrapping within content blocks
-  word-break: break-all; // allow wrapping within content blocks
+  word-break: break-word; // allow wrapping within content blocks
+  white-space: pre-wrap; // prevent wrapping mid-word within content blocks
 }
 
 pre[class*="language-"] code[class*="language-"] {


### PR DESCRIPTION
Inline code blocks were wrapping at the end of the line regardless of how short they are. The issue also seemed to be causing large code blocks to wrap on mobiles and small screens.
