### PR TITLE
Fix code block scrolling

### DIFF
--- a/src/assets/_scss/vendor/_prism.scss
+++ b/src/assets/_scss/vendor/_prism.scss
@@ -11,6 +11,7 @@ pre[class*="language-"] code[class*="language-"] {
   font-size: inherit;
   word-wrap: normal; // prohibit wrapping within code blocks; scroll x overflow
   word-break: normal; // prohibit wrapping within code blocks; scroll x overflow
+  white-space: pre; // prohibit wrapping within code blocks; scroll x overflow
 }
 
 pre[class*="language-"] {


### PR DESCRIPTION
Apologies, I thought I'd tested my previous commit pretty thoroughly but it looks like I re-broke the code block scrolling. This fixes the problem and both inline code and code blocks should be wrapping and scrolling correctly.
