### PR TITLE
Updated list.hbs which just works

### DIFF
--- a/src/partials/post/list.hbs
+++ b/src/partials/post/list.hbs
@@ -8,7 +8,7 @@
     </h2>
   </header>
   <section itemprop="description" class="post-item-excerpt">
-    <p>{{excerpt words="35"}}&hellip;</p>
+    <p>{{excerpt words="200"}}&hellip;</p>
   </section>
   <footer class="post-item-footer">
     <ul class="post-item-meta-list">
@@ -21,6 +21,7 @@
         <li class="post-item-meta-item">
           {{#foreach tags}}
             <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
+            {{#if @last}} {{else}}, {{/if}}
           {{/foreach}}
         </li>
       {{/if}}


### PR DESCRIPTION
Changed the way the tags are shown, now tags will be shown as `tag1, tag2, tag3` 
Previously there were no comma between tags, they were shown as `tag1 tag2 tag3` which looked weird.
Also in the new ghost release `excerpt words=10` will count 10 characters instead of 10 words. updated that to make atleast a paragraph of words.

Working demo at http://www.subho.me
