### PR TITLE
Added missing commas in post tags

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -16,6 +16,7 @@
                 <li class="post-meta-item">
                   {{#foreach tags}}
                     <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
+					{{#if @last}} {{else}}, {{/if}}
                   {{/foreach}}
                 </li>
               {{/if}}

--- a/src/post.hbs
+++ b/src/post.hbs
@@ -16,6 +16,7 @@
                 <li class="post-meta-item">
                   {{#foreach tags}}
                     <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
+					{{#if @last}} {{else}}, {{/if}}
                   {{/foreach}}
                 </li>
               {{/if}}


### PR DESCRIPTION
The tags in the post page are missing commas.
