### PR TITLE
Fix excerpt words count

### DIFF
--- a/partials/post/list.hbs
+++ b/partials/post/list.hbs
@@ -8,7 +8,7 @@
     </h2>
   </header>
   <section itemprop="description" class="post-item-excerpt">
-    <p>{{excerpt characters="15"}}&hellip;</p>
+    <p>{{excerpt words="35"}}&hellip;</p>
   </section>
   <footer class="post-item-footer">
     <ul class="post-item-meta-list">


### PR DESCRIPTION
Update list.hbs to reflect changes in the /src/ file. Show 35 words in the excerpt instead of only 15 characters.
