### PR TITLE
Add linked tag support

### DIFF
--- a/src/partials/post/list.hbs
+++ b/src/partials/post/list.hbs
@@ -20,8 +20,8 @@
       {{#if tags}}
         <li class="post-item-meta-item">
           {{#foreach tags}}
-            <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
-            {{#if @last}} {{else}}, {{/if}}
+            <a itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}" href="{{url}}">{{name}}</a>
+            {{~#if @last}} {{else}}, {{/if}}
           {{/foreach}}
         </li>
       {{/if}}


### PR DESCRIPTION
The following PR shows how to add linked tag support to Ghostium. Feel free to close this and implement it in a different way if preferred. I just wanted to demonstrate what the required changes are, and PR was easiest :smile:

closes #78
- Changed the html wrapping each tag to be an `<a>` instead of a `<span>` - not sure if the span was needed for some other purpose?
- Added a href using the `{{url}}` helper
- Prefixed if with a `~` to collapse whitespace
