### PR TITLE
Making tags linked (thanks @spacecowboy)

### DIFF
--- a/partials/post/list.hbs
+++ b/partials/post/list.hbs
@@ -20,7 +20,7 @@
       {{#if tags}}
         <li class="post-item-meta-item">
           {{#foreach tags}}
-            <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
+            <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}"><a href="{{@blog.url}}/tag/{{name}}">{{name}}</a></span>
             {{#if @last}} {{else}}, {{/if}}
           {{/foreach}}
         </li>

--- a/post.hbs
+++ b/post.hbs
@@ -15,7 +15,7 @@
               {{#if tags}}
                 <li class="post-meta-item">
                   {{#foreach tags}}
-                    <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}">{{name}}</span>
+                    <span itemprop="{{#if @first}}articleSection{{else}}keywords{{/if}}"><a href="{{@blog.url}}/tag/{{name}}">{{name}}</a></span>
                   {{/foreach}}
                 </li>
               {{/if}}


### PR DESCRIPTION
This makes post tags and excerpt tags links to the actual tags. I definitely stole the idea from @spacecowboy in his fork, and figured I'd do it on a merge-able branch.
