### PR TITLE
make the height of avatar unconstrained in post-single page

### DIFF
--- a/src/assets/_scss/partials/_post-single.scss
+++ b/src/assets/_scss/partials/_post-single.scss
@@ -51,7 +51,6 @@
 
 .post-author-avatar {
   width: 80px;
-  height: 80px;
   display: block;
   margin-bottom: 10px;
 


### PR DESCRIPTION
In the post-single page, the `a` with `post-author-avatar` class element has `width:80px;height:80px;` css rules, but just with `width:100%` of inner image.If user's avatar isn't a square, UI breaks. See:

![screen shot 2014-12-08 at 13 28 58](https://cloud.githubusercontent.com/assets/2620575/5335306/c9b1a174-7ee1-11e4-9e4b-1b8b342b921c.png)

There're 2 solutions: constrain the avatar size width equal height or just constrain the width to 80 pixel. I think the second solution is the best.
