### PR TITLE
Fix error in javascript when navigating to home from a static page

### DIFF
--- a/src/assets/js/scripts.js
+++ b/src/assets/js/scripts.js
@@ -79,7 +79,7 @@
         if(posts.length) {
           $head.append($('<script/>', {
             async: true,
-            src: '//' + disqus_shortname + '.disqus.com/count.js?' + posts.join('&')
+            src: '//' + window.disqus_shortname + '.disqus.com/count.js?' + posts.join('&')
           }));
 
           DISQUSWIDGETS.getCount();

--- a/src/assets/js/scripts.js
+++ b/src/assets/js/scripts.js
@@ -79,7 +79,7 @@
         if(posts.length) {
           $head.append($('<script/>', {
             async: true,
-            src: $script.attr('src').split('?')[0] + '?' + posts.join('&')
+            src: '//' + disqus_shortname + '.disqus.com/count.js?' + posts.join('&')
           }));
 
           DISQUSWIDGETS.getCount();


### PR DESCRIPTION
For some reasons that I don't yet understand, when navigating from a static page to the home page by clicking on the navigation panel, there's an error in foot-scripts.js (src/assets/js/scripts.js) on line 82 because `$head.find('script[src*="disqus.com/count-data.js"]')` does not return any element.

To fix this, instead of using `$script.attr('src').split('?')[0]`, I use `'//' + disqus_shortname + '.disqus.com/count.js?'`