### PR TITLE
fix (ghost-0.7): Adds JQuery back into theme

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -38,6 +38,7 @@
 
     <link rel="stylesheet" href="{{asset 'css/main.min.css'}}"/>
 
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script type="text/javascript">
       {{> custom/config}}
 


### PR DESCRIPTION
The most recent version of Ghost drops including JQuery itself; per http://dev.ghost.org/no-more-jquery/, they advise manually adding the resource if your theme uses it.

This is an extremely quick fix I did just to get my own blog up and running; a slightly better solution would be to conditionally load the script.  It's possible you'd want more permanent, tested solution, but I figured it would still be at least mildly valuable to share my fix back since it doesn't seem like ghostium is updated a huge amount.