### PR TITLE
Adding bower jquery library to the build process.

### DIFF
--- a/src/default.hbs
+++ b/src/default.hbs
@@ -68,6 +68,7 @@
     <!-- build:js /assets/js/head-scripts.min.js -->
     <script src="/assets/_components/modernizr/modernizr.js"></script>
     <script src="/assets/_components/pace/pace.js"></script>
+    <script src="/assets/_components/jquery/jquery.js"></script>
     <!-- endbuild -->
 
     {{ghost_head}}

--- a/src/default.hbs
+++ b/src/default.hbs
@@ -68,7 +68,6 @@
     <!-- build:js /assets/js/head-scripts.min.js -->
     <script src="/assets/_components/modernizr/modernizr.js"></script>
     <script src="/assets/_components/pace/pace.js"></script>
-    <script src="/assets/_components/jquery/jquery.js"></script>
     <!-- endbuild -->
 
     {{ghost_head}}
@@ -116,7 +115,7 @@
     <script src="/assets/_components/prism/components/prism-scss.js"></script>
     <script src="/assets/_components/prism/components/prism-sql.js"></script>
     <script src="/assets/_components/prism/plugins/autolinker/prism-autolinker.js"></script>
-
+    <script src="/assets/_components/jquery/jquery.js"></script>
     <script src="/assets/_components/jquery-pjax/jquery.pjax.js"></script>
     <script src="/assets/js/drawer.js"></script>
     <script src="/assets/js/imageLoader.js"></script>


### PR DESCRIPTION
Since ghost doesn't have jQuery anymore, if you want to build the theme with Grunt doesn't work. Now jQuery is harcoded, because of this reason, the theme works.
With this change the bower jQuery version is used.
So if a new release is generated, the line #41 of default.hbs (the root one) has to be deleted. It's the line which include jQuery from https://code.jquery.com/jquery-1.11.3.min.js
