### PR TITLE
Ghost 1.0 Compatability

### DIFF
--- a/partials/pagination.hbs
+++ b/partials/pagination.hbs
@@ -1,12 +1,12 @@
 <nav role="pagination" class="post-list-pagination">
   {{#if prev}}
-    <a href="{{pageUrl prev}}" class="post-list-pagination-item post-list-pagination-item-prev" data-pjax>
+    <a href="{{page_url prev}}" class="post-list-pagination-item post-list-pagination-item-prev" data-pjax>
       <i class="fa fa-angle-double-left"></i>&nbsp;Newer
     </a>
   {{/if}}
   <span class="post-list-pagination-item post-list-pagination-item-current">Page {{page}} of {{pages}}</span>
   {{#if next}}
-    <a href="{{pageUrl next}}" class="post-list-pagination-item post-list-pagination-item-next" data-pjax>
+    <a href="{{page_url next}}" class="post-list-pagination-item post-list-pagination-item-next" data-pjax>
       Older&nbsp;<i class="fa fa-angle-double-right"></i>
     </a>
   {{/if}}


### PR DESCRIPTION
This fixes the only critical/fatal issue that will mean the theme won't run with Ghost 1.0.
This change is backwards compatible to Ghost 0.4.2, so should have no impact.

Essentially pageUrl was deprecated in favour of page_url in 0.4.2, and removed totally in 1.0.0

There are other recommendations for changes, however they are recommended not required.