### PR TITLE
Upgraded to work in Ghost 1.8.5

### DIFF
--- a/src/page.hbs
+++ b/src/page.hbs
@@ -12,9 +12,9 @@
           </header>
           <aside class="post-side">
             <div class="post-author">
-              {{#if author.image}}
+              {{#if author.profile_image}}
                 <a href="{{author.website}}" class="post-author-avatar">
-                  <img src="{{author.image}}" alt="{{author.name}}">
+                  <img src="{{author.profile_image}}" alt="{{author.name}}">
                 </a>
               {{/if}}
               <div class="post-author-info">
@@ -30,9 +30,9 @@
           </div>
           <footer class="post-footer">
             <div itemprop="author" itemscope itemtype="http://schema.org/Person" class="post-author">
-              {{#if author.image}}
+              {{#if author.profile_image}}
                 <a href="{{author.website}}" class="post-author-avatar">
-                  <img itemprop="image" src="{{author.image}}" alt="{{author.name}}">
+                  <img itemprop="image" src="{{author.profile_image}}" alt="{{author.name}}">
                 </a>
               {{/if}}
               <div class="post-author-info">

--- a/src/partials/cover.hbs
+++ b/src/partials/cover.hbs
@@ -1,5 +1,5 @@
 <aside role="banner" class="cover">
-  <div {{#if @blog.cover}}data-load-image="{{@blog.cover}}"{{/if}} class="cover-image"></div>
+  <div {{#if @blog.cover_image}}data-load-image="{{@blog.cover_image}}"{{/if}} class="cover-image"></div>
   <div class="cover-container">
     {{#if @blog.logo}}
       <a href="{{@blog.url}}" class="cover-logo" data-pjax>

--- a/src/partials/pagination.hbs
+++ b/src/partials/pagination.hbs
@@ -1,12 +1,12 @@
 <nav role="pagination" class="post-list-pagination">
   {{#if prev}}
-    <a href="{{pageUrl prev}}" class="post-list-pagination-item post-list-pagination-item-prev" data-pjax>
+    <a href="{{page_url prev}}" class="post-list-pagination-item post-list-pagination-item-prev" data-pjax>
       <i class="fa fa-angle-double-left"></i>&nbsp;Newer
     </a>
   {{/if}}
   <span class="post-list-pagination-item post-list-pagination-item-current">Page {{page}} of {{pages}}</span>
   {{#if next}}
-    <a href="{{pageUrl next}}" class="post-list-pagination-item post-list-pagination-item-next" data-pjax>
+    <a href="{{page_url next}}" class="post-list-pagination-item post-list-pagination-item-next" data-pjax>
       Older&nbsp;<i class="fa fa-angle-double-right"></i>
     </a>
   {{/if}}

--- a/src/post.hbs
+++ b/src/post.hbs
@@ -21,7 +21,7 @@
                 </li>
               {{/if}}
               <li class="post-meta-item">
-                <a href="#disqus_thread" data-disqus-identifier="{{id}}">Comments</a>
+                <a href="#disqus_thread" data-disqus-identifier="{{comment_id}}">Comments</a>
               </li>
             </ul>
             <h1 itemprop="name headline" class="post-title"><a href="{{url}}" itemprop="url" data-pjax title="{{{title}}}">{{{title}}}</a></h1>
@@ -30,9 +30,9 @@
           </header>
           <aside class="post-side">
             <div class="post-author">
-              {{#if author.image}}
+              {{#if author.profile_image}}
                 <a href="{{author.website}}" class="post-author-avatar">
-                  <img src="{{author.image}}" alt="{{author.name}}">
+                  <img src="{{author.profile_image}}" alt="{{author.name}}">
                 </a>
               {{/if}}
               <div class="post-author-info">
@@ -48,9 +48,9 @@
           </div>
           <footer class="post-footer">
             <div itemprop="author" itemscope itemtype="http://schema.org/Person" class="post-author">
-              {{#if author.image}}
+              {{#if author.profile_image}}
                 <a href="{{author.website}}" class="post-author-avatar">
-                  <img itemprop="image" src="{{author.image}}" alt="{{author.name}}">
+                  <img itemprop="image" src="{{author.profile_image}}" alt="{{author.name}}">
                 </a>
               {{/if}}
               <div class="post-author-info">
@@ -94,7 +94,7 @@
 <script type="text/javascript">
   if(GHOSTIUM.haveDisqus) {
     {{#post}}
-    var disqus_identifier = '{{id}}';
+    var disqus_identifier = '{{comment_id}}';
     {{/post}}
 
     if(typeof DISQUS !== 'object') {


### PR DESCRIPTION
Fixed issues when importing the theme in latest version of Ghost (1.8.5).

Unlike the other 4 similar pull requests, this one only changes files in the `src` folder. I have tested running a Grunt build and then using the generated files from `build` and that works fine too. 